### PR TITLE
feat: Add from_reqwest_client method to use existing reqwest client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,13 @@ impl Client {
         }
     }
 
+    pub fn from_reqwest_client(client: ReqwestClient, api_key: &str) -> Client {
+        Client {
+            api_key: api_key.to_owned(),
+            client,
+        }
+    }
+
     /// Build a new URL with given query params pointing to the LastFM APIs.
     async fn build_url(&self, params: Vec<(&str, &str)>) -> Url {
         let mut url = Url::parse("http://ws.audioscrobbler.com/2.0/").unwrap();


### PR DESCRIPTION
I think it would be useful to be able to use an existing reqwest client and not create a new one internally.

I already keep another reqwest client around, and since it holds a connection pool internally it would be nice to reuse the same one.  😃  Can just clone a reqwest Client into `from_reqwest_client` as it uses an Arc internally.