### PR TITLE
Deserialize timestamps into chrono::DateTime<Utc>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name            = "lastfm_rs"
 path            = "src/lib.rs"
 
 [dependencies]
+chrono          = { version = "0.4", features = ["serde"] }
 futures         = "0.3.8"
 serde           = { version = "1.0.118", features = ["derive"] }
 serde_json      = "1.0.60"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod error;
 pub mod macros;
 pub mod model;
 pub mod user;
+mod util;
 
 /// The Request Builder.
 ///

--- a/src/user/loved_tracks.rs
+++ b/src/user/loved_tracks.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use chrono::serde::ts_seconds::deserialize as from_ts;
 use serde::Deserialize;
 use std::marker::PhantomData;
 
@@ -7,6 +6,7 @@ use crate::{
     error::{Error, LastFMError},
     model::{Attributes, Image},
     user::User,
+    util::deserialize_datetime_from_str,
     Client, RequestBuilder,
 };
 
@@ -60,14 +60,14 @@ pub struct Artist {
 
 #[derive(Debug, Deserialize)]
 pub struct Date {
-    /// The timestamp of a [Track] in the form of a UNIX Epoch /
-    /// Timestamp.
+    /// The date of a [Track] in UTC
     #[serde(rename = "uts")]
-    pub unix_timestamp: String,
-    /// The date of when a [Track] was first scrobbled on Last.fm.
-    #[serde(rename = "#text")]
-    #[serde(deserialize_with = "from_ts")]
+    #[serde(deserialize_with = "deserialize_datetime_from_str")]
     pub date: DateTime<Utc>,
+    /// The date of when a [Track] was first scrobbled on Last.fm, formatted as
+    /// `%d %b %Y, %H:%M`, for example: "11 Dec 2020, 23:12"
+    #[serde(rename = "#text")]
+    pub date_formatted: String,
 }
 
 /// The streamable struct.

--- a/src/user/loved_tracks.rs
+++ b/src/user/loved_tracks.rs
@@ -1,3 +1,5 @@
+use chrono::{DateTime, Utc};
+use chrono::serde::ts_seconds::deserialize as from_ts;
 use serde::Deserialize;
 use std::marker::PhantomData;
 
@@ -62,10 +64,10 @@ pub struct Date {
     /// Timestamp.
     #[serde(rename = "uts")]
     pub unix_timestamp: String,
-    /// The friendly date of when a [Track] was first scrobbled
-    /// on Last.fm.
+    /// The date of when a [Track] was first scrobbled on Last.fm.
     #[serde(rename = "#text")]
-    pub friendly_date: String,
+    #[serde(deserialize_with = "from_ts")]
+    pub date: DateTime<Utc>,
 }
 
 /// The streamable struct.

--- a/src/user/recent_tracks.rs
+++ b/src/user/recent_tracks.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use chrono::serde::ts_seconds::deserialize as from_ts;
 use serde::Deserialize;
 use std::marker::PhantomData;
 
@@ -7,6 +6,7 @@ use crate::{
     error::{Error, LastFMError},
     model::{Attributes, Image},
     user::User,
+    util::deserialize_datetime_from_str,
     Client, RequestBuilder,
 };
 
@@ -74,14 +74,15 @@ pub struct TrackAttributes {
 
 #[derive(Debug, Deserialize)]
 pub struct Date {
-    /// The timestamp of a [Track] in the form of a UNIX Epoch /
-    /// Timestamp.
+    /// The date of a [Track] in UTC
     #[serde(rename = "uts")]
-    pub unix_timestamp: String,
-    /// The date of when a [Track] was first scrobbled on Last.fm.
-    #[serde(rename = "#text")]
-    #[serde(deserialize_with = "from_ts")]
+    #[serde(deserialize_with = "deserialize_datetime_from_str")]
     pub date: DateTime<Utc>,
+
+    /// The date of when a [Track] was first scrobbled on Last.fm, formatted as
+    /// `%d %b %Y, %H:%M`, for example: "11 Dec 2020, 23:12"
+    #[serde(rename = "#text")]
+    pub date_formatted: String,
 }
 
 impl RecentTracks {

--- a/src/user/recent_tracks.rs
+++ b/src/user/recent_tracks.rs
@@ -1,5 +1,6 @@
+use chrono::{DateTime, Utc};
+use chrono::serde::ts_seconds::deserialize as from_ts;
 use serde::Deserialize;
-
 use std::marker::PhantomData;
 
 use crate::{
@@ -77,10 +78,10 @@ pub struct Date {
     /// Timestamp.
     #[serde(rename = "uts")]
     pub unix_timestamp: String,
-    /// The friendly date of when a [Track] was first scrobbled
-    /// on Last.fm.
+    /// The date of when a [Track] was first scrobbled on Last.fm.
     #[serde(rename = "#text")]
-    pub friendly_date: String,
+    #[serde(deserialize_with = "from_ts")]
+    pub date: DateTime<Utc>,
 }
 
 impl RecentTracks {

--- a/src/user/user_info.rs
+++ b/src/user/user_info.rs
@@ -1,3 +1,5 @@
+use chrono::{DateTime, Utc};
+use chrono::serde::ts_seconds::deserialize as from_ts;
 use serde::Deserialize;
 use std::marker::PhantomData;
 
@@ -47,13 +49,12 @@ pub struct Registered {
     /// The UNIX timestamp of when the user registered their Last.fm account.
     #[serde(rename = "unixtime")]
     pub unix_timestamp: String,
-    /// The i64 timestamp of when the user registered their Last.fm account. This
-    /// is necessary to be in i64 for when users want to use the [chrono] date & time
-    /// library.
+    /// [chrono] DateTime
     ///
     /// [chrono]: https://crates.io/crates/chrono
     #[serde(rename = "#text")]
-    pub friendly_date: i64,
+    #[serde(deserialize_with = "from_ts")]
+    pub date: DateTime<Utc>,
 }
 
 impl UserInfo {

--- a/src/user/user_info.rs
+++ b/src/user/user_info.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, Utc};
 use chrono::serde::ts_seconds::deserialize as from_ts;
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use std::marker::PhantomData;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,13 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{de, Deserialize, Deserializer};
+
+pub fn deserialize_datetime_from_str<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    let timestamp = s.parse::<i64>().map_err(de::Error::custom)?;
+
+    let naive_datetime = NaiveDateTime::from_timestamp(timestamp, 0);
+    Ok(DateTime::from_utc(naive_datetime, Utc))
+}


### PR DESCRIPTION
Another breaking change 😬 

I think it would be useful to deserialize timestamps directly into `DateTime<Utc>`s.   Not sure about the field naming, since sometimes it's repeated like `Track.date.date`

Added a `deserialize_datetime_from_str` helper function to deserialize string unix times to DateTime<Utc>.  Also I'm not too sure about the module name, `util` is a bit vague so some suggestions for a different name if any would be nice 😄 