### PR TITLE
fix: Use actual source for Error::source instead of self

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,13 @@ pub enum Error {
 }
 
 impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> { Some(self) }
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match *self {
+            Error::ParsingError(ref e) => Some(e),
+            Error::HTTPError(ref e) => Some(e),
+            Error::LastFMError(_) => None,
+        }
+    }
 }
 
 impl Display for Error {


### PR DESCRIPTION
May cause infinite looping with certain libraries that rely on iterating over error source, e.g. [sentry-rs](https://github.com/getsentry/sentry-rust/blob/2a64a98b5941aa70c03d0658c79a289609f03f36/sentry-core/src/error.rs#L86-L89).