### PR TITLE
Struct refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde           = { version = "1.0.125", features = ["derive"] }
 serde_json      = "1.0.64"
 reqwest         = { version = "0.11.2", features = ["json"] }
 url             = "2.2.1"
+void            = "1.0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod error;
 pub mod macros;
 pub mod model;
 pub mod user;
+pub mod track;
 pub mod utilities;
 
 const WS_ENDPOINT: &str = "http://ws.audioscrobbler.com/2.0/";

--- a/src/model/custom_deserialization.rs
+++ b/src/model/custom_deserialization.rs
@@ -1,0 +1,85 @@
+// The following code is adapted from https://serde.rs/string-or-struct.html
+// as it appears on 2021-05-29
+
+// the `string_or_struct` function uses these impl to instantiate a Type
+// if the input file contains a string and not a struct.
+
+use serde::{Deserialize, Deserializer};
+use serde::de::{self, MapAccess, Visitor};
+use std::fmt;
+use std::marker::PhantomData;
+use std::str::FromStr;
+use void::Void;
+
+pub fn option_string_or_struct<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de> + FromStr<Err = Void>,
+    D: Deserializer<'de>,
+{
+    struct OptionStringOrStruct<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for OptionStringOrStruct<Option<T>>
+    where
+        T: Deserialize<'de> + FromStr<Err = Void>,
+    {
+        type Value = Option<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("null, string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Option<T>, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(FromStr::from_str(value).unwrap()))
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<Option<T>, M::Error>
+        where
+            M: MapAccess<'de>
+        {
+            match Deserialize::deserialize(de::value::MapAccessDeserializer::new(map)) {
+                Ok(res) => Ok(Some(res)),
+                Err(err) => Err(err),
+            }
+        }
+    }
+
+    deserializer.deserialize_any(OptionStringOrStruct(PhantomData))
+}
+
+pub fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + FromStr<Err = Void>,
+    D: Deserializer<'de>,
+{
+    struct StringOrStruct<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for StringOrStruct<T>
+    where
+        T: Deserialize<'de> + FromStr<Err = Void>,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            Ok(FromStr::from_str(value).unwrap())
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<T, M::Error>
+        where
+            M: MapAccess<'de>
+        {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrStruct(PhantomData))
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,10 +3,15 @@
 //! These are the various models the crate uses throughout the library, centralized
 //! in this file to ease development and remove code duplication.
 
+use crate::model::custom_deserialization::{string_or_struct, option_string_or_struct};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::str::FromStr;
+use void::Void;
 
 use crate::utilities::deserialize_datetime_from_str;
+
+pub mod custom_deserialization;
 
 /// Various attributes transmitted by several API endpoints.
 #[derive(Debug, Deserialize)]
@@ -55,3 +60,112 @@ pub struct Image {
     #[serde(rename = "#text")]
     pub image_url: String,
 }
+
+/// Contains information about the given track
+#[derive(Debug, Deserialize)]
+pub struct Track {
+    /// The artist who published the  given track.
+    #[serde(deserialize_with = "string_or_struct")]
+    pub artist: Artist,
+    /// Various attributes associated with the track.
+    #[serde(rename = "@attr")]
+    pub attrs: Option<TrackAttributes>,
+    /// The MusicBrainz ID for the given track.
+    pub mbid: Option<String>,
+    /// The name of the track.
+    pub name: String,
+    /// The album the track is associated with.
+    pub album: Option<Album>,
+    /// The last.fm URL of the track.
+    pub url: String,
+    /// Images associated with the track.
+    #[serde(rename = "image")]
+    pub images: Vec<Image>,
+    /// The date of when the track was scrobbled. 
+    /// Returned when output comes from some endpoints such as loved_tracks
+    pub date: Option<TrackDate>,
+    /// Whether or not the track is streamable
+    #[serde(deserialize_with = "option_string_or_struct")]
+    pub streamable: Option<Streamable>,
+    /// The match for the given track
+    /// Returned when output comes from some endpoints such as similar
+    pub r#match: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TrackAttributes {
+    /// Whether or not the user's first available track is the
+    /// one the user is currently playing.
+    #[serde(rename = "nowplaying")]
+    pub now_playing: Option<String>,
+}
+
+impl FromStr for Streamable {
+    type Err = Void;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Streamable {
+            text: s.to_string(),
+            fulltrack: None,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Album {
+    /// The name of the album.
+    #[serde(rename = "#text")]
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Artist {
+    /// The name of the artist.
+    #[serde(alias = "#text")]
+    pub name: String,
+    /// The last.fm URL for the given artist.
+    pub url: Option<String>,
+    /// The MusicBrainz ID of the given artist.
+    pub mbid: Option<String>,
+    /// Attributes associated with the artist.
+    #[serde(rename = "@attr")]
+    pub attrs: Option<ArtistAttributes>,
+    /// How many times the user has scrobbled the artist.
+    #[serde(rename = "playcount")]
+    pub scrobbles: Option<String>,
+    /// The main images linked to the artist.
+    #[serde(rename = "image")]
+    pub images: Option<Vec<Image>>,
+}
+
+impl FromStr for Artist {
+    type Err = Void;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Artist {
+            name: s.to_string(),
+            url: None,
+            mbid: None,
+            attrs: None,
+            scrobbles: None,
+            images: None,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ArtistAttributes {
+    /// Where the artist is ranked in the user's profile.
+    pub rank: Option<String>,
+}
+
+/// The streamable struct.
+///
+/// Available if the given track is available for streaming.
+#[derive(Debug, Deserialize)]
+pub struct Streamable {
+    pub fulltrack: Option<String>,
+    #[serde(rename = "#text")]
+    pub text: String,
+}
+

--- a/src/track/mod.rs
+++ b/src/track/mod.rs
@@ -1,0 +1,14 @@
+//! Last.fm Track API Endpoints
+//!
+//! Contains structs and methods related to working with the track-related endpoints
+//! available through the Last.fm API
+
+use serde::Deserialize;
+
+pub mod similar;
+
+#[derive(Debug, Deserialize)]
+pub struct Track {
+    #[serde(rename = "similartracks")]
+    pub similar_tracks: Option<similar::Similar>,
+}

--- a/src/track/mod.rs
+++ b/src/track/mod.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 pub mod similar;
 
 #[derive(Debug, Deserialize)]
-pub struct Track {
+pub struct Endpoints {
     #[serde(rename = "similartracks")]
     pub similar_tracks: Option<similar::Similar>,
 }

--- a/src/track/similar.rs
+++ b/src/track/similar.rs
@@ -1,0 +1,102 @@
+use serde::Deserialize;
+use std::marker::PhantomData;
+
+use crate::{
+    error::{Error, LastFMError},
+    model::{Attributes, Image},
+    track::{Track as OriginalTrack},
+    Client, RequestBuilder,
+};
+
+/// The main similar structure.
+///
+/// This is split off into two areas: One, the attributes (used
+/// for displaying various user-associated attributes), and two,
+/// the similar tracks to the one provided.
+///
+/// For details on the attributes available, refer to [Attributes]. For
+/// details on the track information available, refer to [Track].
+#[derive(Debug, Deserialize)]
+pub struct Similar {
+    /// A [Vec] containing similar [Track]s.
+    #[serde(rename = "track")]
+    pub tracks: Vec<Track>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Track {
+    /// The name of the given track
+    pub name: String,
+    /// The MusicBrainz ID for the given track.
+    pub mbid: Option<String>,
+    /// The match for the given track
+    pub r#match: f32,
+    /// The Last.fm URL of the track
+    pub url: String,
+    /// Whether or not the track is streamable
+    pub streamable: Streamable,
+    /// the artist who published the given track
+    pub artist: Artist,
+    /// The cover art for the given track. Available in small, medium,
+    /// and large sizes.
+    #[serde(rename="image")]
+    pub images: Vec<Image>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Artist {
+    /// The name of the given artist
+    pub name: String,
+    /// The MusicBrainz ID of the given artist
+    pub mbid: Option<String>,
+    /// The Last.fm URL for the given artist
+    pub url: String,
+}
+
+/// The streamable struct.
+///
+/// Available if the given track is available for streaming.
+#[derive(Debug, Deserialize)]
+pub struct Streamable {
+    pub fulltrack: String,
+    #[serde(rename = "#text")]
+    pub text: String,
+}
+
+impl Similar {
+    pub async fn build_by_mbid<'a>(client: &'a mut Client, mbid: &str) -> RequestBuilder<'a, Similar> {
+        let url = client.build_url(vec![("method", "track.getSimilar"), ("mbid", mbid)]).await;
+        RequestBuilder { client, url, phantom: PhantomData }
+    }
+
+    pub async fn build<'a>(client: &'a mut Client, artist: &str, track: &str) -> RequestBuilder<'a, Similar> {
+        let url = client.build_url(vec![("method", "track.getSimilar"), ("artist", artist), ("track", track)]).await;
+        RequestBuilder { client, url, phantom: PhantomData }
+    }
+}
+
+impl<'a> RequestBuilder<'a, Similar> {
+    add_param!(with_limit, limit, usize);
+
+    pub async fn send(&'a mut self) -> Result<Similar, Error> {
+        match self.client.request(&self.url).await {
+            Ok(response) => {
+                let body = response.text().await.unwrap();
+                match serde_json::from_str::<LastFMError>(&body) {
+                    Ok(lastfm_error) => Err(Error::LastFMError(lastfm_error.into())),
+                    Err(_) => match serde_json::from_str::<OriginalTrack>(&body) {
+                        Ok(tracks) => Ok(tracks.similar_tracks.unwrap()),
+                        Err(e) => Err(Error::ParsingError(e)),
+                    },
+                }
+            }
+            Err(err) => Err(Error::HTTPError(err)),
+        }
+    }
+}
+
+impl<'a> Client {
+    pub async fn similar_tracks_by_mbid(&'a mut self, mbid: &str) -> RequestBuilder<'a, Similar> { Similar::build_by_mbid(self, mbid).await }
+
+    pub async fn similar_tracks(&'a mut self, artist: &str, track: &str) -> RequestBuilder<'a, Similar> { Similar::build(self, artist, track).await }
+}

--- a/src/user/loved_tracks.rs
+++ b/src/user/loved_tracks.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 
 use crate::{
     error::{Error, LastFMError},
-    model::{Attributes, Image, TrackDate},
-    user::User,
+    model::Attributes,
+    user::{User, Track},
     Client, RequestBuilder,
 };
 
@@ -26,48 +26,6 @@ pub struct LovedTracks {
     /// on Last.fm.
     #[serde(rename = "track")]
     pub tracks: Vec<Track>,
-}
-
-/// Contains information about the given track that the
-/// user Loved.
-#[derive(Debug, Deserialize)]
-pub struct Track {
-    /// The artist who published the given track.
-    pub artist: Artist,
-    /// The MusicBrainz ID for the given track.
-    pub mbid: String,
-    /// The date of when the user loved the track.
-    pub date: Option<TrackDate>,
-    /// The name of the track.
-    pub name: String,
-    /// The Last.fm URL of the track.
-    pub url: String,
-    /// The cover art for the given track. Available in small, medium,
-    /// and large sizes.
-    #[serde(rename = "image")]
-    pub images: Vec<Image>,
-    /// Whether or not the track is streamable.
-    pub streamable: Streamable,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Artist {
-    /// The Last.fm URL for the given artist.
-    pub url: String,
-    /// The name of the given artist.
-    pub name: String,
-    /// The MusicBrainz ID of the given artist.
-    pub mbid: String,
-}
-
-/// The streamable struct.
-///
-/// Available if the given track is available for streaming.
-#[derive(Debug, Deserialize)]
-pub struct Streamable {
-    pub fulltrack: String,
-    #[serde(rename = "#text")]
-    pub text: String,
 }
 
 impl LovedTracks {

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -3,6 +3,7 @@
 //! Contains structs and methods related to working with the user-related endpoints
 //! available through the Last.fm API.
 
+use crate::model::{Track, Artist};
 use serde::Deserialize;
 
 pub mod loved_tracks;

--- a/src/user/recent_tracks.rs
+++ b/src/user/recent_tracks.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 
 use crate::{
     error::{Error, LastFMError},
-    model::{Attributes, Image, TrackDate},
-    user::User,
+    model::Attributes,
+    user::{User, Track},
     Client, RequestBuilder,
 };
 
@@ -24,50 +24,6 @@ pub struct RecentTracks {
     /// A [Vec] containiing recent [Track]s.
     #[serde(rename = "track")]
     pub tracks: Vec<Track>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Track {
-    /// The primary artist associated with the track.
-    pub artist: Artist,
-    /// Various attributes associated with the track.
-    #[serde(rename = "@attr")]
-    pub attrs: Option<TrackAttributes>,
-    /// The name of the track.
-    pub name: String,
-    /// The album the track is associated with.
-    pub album: Album,
-    /// The last.fm URL of the track.
-    pub url: String,
-    /// Whether or not a track is streamable.
-    pub streamable: String,
-    /// Images associated with the track.
-    #[serde(rename = "image")]
-    pub images: Vec<Image>,
-    /// The date of when the track was scrobbled.
-    pub date: Option<TrackDate>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Artist {
-    /// The name of the artist.
-    #[serde(rename = "#text")]
-    pub name: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Album {
-    /// The name of the album.
-    #[serde(rename = "#text")]
-    pub name: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct TrackAttributes {
-    /// Whether or not the user's first available track is the
-    /// one the user is currently playing.
-    #[serde(rename = "nowplaying")]
-    pub now_playing: String,
 }
 
 impl RecentTracks {

--- a/src/user/top_artists.rs
+++ b/src/user/top_artists.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 
 use crate::{
     error::{Error, LastFMError},
-    model::{Attributes, Image},
-    user::User,
+    model::Attributes,
+    user::{User, Artist},
     Client, RequestBuilder,
 };
 
@@ -23,31 +23,6 @@ pub struct TopArtists {
     /// Various internal API attributes.
     #[serde(rename = "@attr")]
     pub attrs: Attributes,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Artist {
-    /// Attributes associated with the artist.
-    #[serde(rename = "@attr")]
-    pub attrs: ArtistAttributes,
-    /// The MusicBrainz ID for the artist.
-    pub mbid: String,
-    /// How many times the user has scrobbled the artist.
-    #[serde(rename = "playcount")]
-    pub scrobbles: String,
-    /// The name of the artist.
-    pub name: String,
-    /// The Last.fm URL for the artist.
-    pub url: String,
-    /// The main images linked to the artist.
-    #[serde(rename = "image")]
-    pub images: Vec<Image>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ArtistAttributes {
-    /// Where the artist is ranked in the user's profile.
-    pub rank: String,
 }
 
 impl TopArtists {


### PR DESCRIPTION
Adding in the Similar track code I noticed it was implemented so that a `Track` was different depending on which endpoint it came from. I've refactored the structs so that, for example, a Track is a Track no matter the endpoint it came from. The trade off is a number of the fields become `Option` since last.fm is a little inconsistent in what information it returns. But I felt from the perspective of someone using the library this would be an improvement. Going forward it will also decrease the amount of code that needs to be written.
